### PR TITLE
Draft for copy as code using Nunjucks

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,5 +26,6 @@
   "minimum_chrome_version": "18.0",
   "devtools_page": "devtools.html",
   "permissions": ["storage"],
-  "optional_permissions": ["*://*/*"]
+  "optional_permissions": ["*://*/*"],
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
   "homepage": "https://github.com/poplindata/chrome-snowplow-inspector#readme",
   "dependencies": {
     "@snowplow/browser-tracker": "^3.1.1",
+    "@types/nunjucks": "^3.2.1",
     "bulma": "^0.7.5",
     "canonicalize": "^1.0.5",
     "jsonschema": "1.*",
-    "mithril": "2.*"
+    "mithril": "2.*",
+    "nunjucks": "^3.2.3"
   },
   "devDependencies": {
     "@parcel/transformer-sass": "^2.0.0",
@@ -40,6 +42,7 @@
     "buffer": "^6.0.3",
     "parcel": "^2.0.0",
     "prettier": "^2.3.2",
+    "process": "^0.11.10",
     "querystring-es3": "^0.2.1",
     "sass": "^1.23.7",
     "tslib": "*",


### PR DESCRIPTION
So this needs some clean up and extra work (page views, structured events) but wanted to get your feedback before I take it any further.

- Is Nunjucks overkill here? It does make it a bit easier to template than just straight ES6 but it also seems to require unsafe-eval which is not ideal.

- Can we practically generate type definitions for every language for data objects or are we better off with a 'simple' method of deserialising the JSON and then sending it in an event? (even then we may get stuck if the deserialising requires a class / object definition).

- Do we both with contexts at all? It seems semi-useful but then again a large number of web contexts may not necessarily apply to other trackers.