### PR TITLE
Read network user ID from response cookies (close #65)

### DIFF
--- a/src/components/Debugger/Timeline.tsx
+++ b/src/components/Debugger/Timeline.tsx
@@ -270,10 +270,7 @@ const extractNetworkUserId = (cookies: Cookie[]): Cookie | undefined => {
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const uuidCookies = cookies.filter((x) => uuidRegexp.test(x.value));
   // prefer a cookie with the name `sp` or take the first one
-  return (
-    uuidCookies.find((x) => x.name === "sp") ??
-    (uuidCookies.length > 0 ? uuidCookies[0] : undefined)
-  );
+  return uuidCookies.find((x) => x.name === "sp") ?? uuidCookies.shift();
 };
 
 const extractRequests = (

--- a/src/components/Debugger/Timeline.tsx
+++ b/src/components/Debugger/Timeline.tsx
@@ -267,7 +267,7 @@ const getPageUrl = (entries: Entry[]) => {
 const extractNetworkUserId = (cookies: Cookie[]): Cookie | undefined => {
   // consider only cookies with the UUID format
   const uuidRegexp =
-    /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const uuidCookies = cookies.filter((x) => uuidRegexp.test(x.value));
   // prefer a cookie with the name `sp` or take the first one
   return (

--- a/src/components/Debugger/Timeline.tsx
+++ b/src/components/Debugger/Timeline.tsx
@@ -272,7 +272,7 @@ const extractNetworkUserId = (cookies: Cookie[]): Cookie | undefined => {
   // prefer a cookie with the name `sp` or take the first one
   return (
     uuidCookies.find((x) => x.name === "sp") ??
-    (uuidCookies.length > 0 ? cookies[0] : undefined)
+    (uuidCookies.length > 0 ? uuidCookies[0] : undefined)
   );
 };
 


### PR DESCRIPTION
Issue #65 

This PR addresses the issue with network user ID not being shown for the first request to the collector which doesn't yet have the cookie in the request header, but gets the cookie in the response.

The solution is to read the network user ID from the response. I kept the logic that a cookie with an `sp` name is preferred but also enabled other cookies with a UUID format to be accepted as @jethron suggested in the issue.

My initial goal was to keep reading the cookies from the request and fall back on the response cookies in case the `nuid` is not in the request one. But I came to the conclusion that it's probably better to always read from the response cookie for the following reason:

* In case there are multiple trackers on the page with the same domain (see docs.snowplow.io as an example), the request cookies will have `nuid` values for all of them and the extension doesn't know which one is the correct one. However, the response cookie only contains the `nuid` set by the collector we made the request to so we can be sure it's the correct one.

I couldn't think of a case where the response cookies would be less reliable than the request cookies. But if you can think of anything, please let me know!