### PR TITLE
Prevent requests for attribute values without auth

### DIFF
--- a/src/components/Signals/Attributes.tsx
+++ b/src/components/Signals/Attributes.tsx
@@ -28,6 +28,7 @@ type ResourceDefinitions =
       info: SignalsInstall;
       keys: AttributeKey[];
       groups: AttributeGroup[];
+      hasAuth: boolean;
     }
   | undefined;
 
@@ -45,6 +46,12 @@ const cache = new Map<
   )[]
 >();
 
+const SetAPIKeyButton: FunctionComponent = () => (
+  <button type="button" onClick={() => chrome.runtime.openOptionsPage()}>
+    Click here to set an API key to access attribute values
+  </button>
+);
+
 const AttributeGroupData: FunctionComponent<{
   client: SignalsClient;
   eventCount?: number;
@@ -56,6 +63,7 @@ const AttributeGroupData: FunctionComponent<{
   orgName: string;
   label: string;
   refresh: number;
+  hasAuth: boolean;
 }> = ({
   client,
   eventCount,
@@ -67,6 +75,7 @@ const AttributeGroupData: FunctionComponent<{
   orgName,
   label,
   refresh,
+  hasAuth,
 }) => {
   useErrorBoundary(errorAnalytics);
   const [version, setVersion] = useState(
@@ -120,6 +129,19 @@ const AttributeGroupData: FunctionComponent<{
 
     const fetchForIdentifier = (identifier: string, i: number) => {
       if (!attributeNames.length) return Promise.resolve();
+
+      if (!hasAuth) {
+        setValues((current) => {
+          const updated = [...current];
+          updated[i] = {
+            attributeKey: attribute_key.name,
+            identifier,
+          };
+          return updated;
+        });
+        return Promise.resolve();
+      }
+
       return client
         .getGroupAttributes({
           name,
@@ -185,7 +207,7 @@ const AttributeGroupData: FunctionComponent<{
       cancelled = true;
       clearTimeout(timeout);
     };
-  }, [identifiers, version, eventCount, refresh]);
+  }, [identifiers, version, eventCount, refresh, hasAuth]);
 
   if (!values.some(Boolean)) return null;
 
@@ -232,6 +254,21 @@ const AttributeGroupData: FunctionComponent<{
       {values.map((result) => {
         if (!result) return;
         const { attributeKey, identifier, ...attributes } = result;
+
+        if (!hasAuth) {
+          return (
+            <table key={identifier}>
+              <tbody>
+                <tr>
+                  <th colSpan={2}>
+                    <SetAPIKeyButton />
+                  </th>
+                </tr>
+              </tbody>
+            </table>
+          );
+        }
+
         const filtered = Object.entries(attributes).filter(
           ([attribute, value]) => {
             if (!filter) return true;
@@ -278,12 +315,7 @@ const AttributeGroupData: FunctionComponent<{
                     ) ? (
                       <span>{JSON.stringify(value, null, 2)}</span>
                     ) : (
-                      <button
-                        type="button"
-                        onClick={() => chrome.runtime.openOptionsPage()}
-                      >
-                        Click here to set an API key to access attribute values
-                      </button>
+                      <SetAPIKeyButton />
                     )}
                   </td>
                 </tr>
@@ -321,6 +353,7 @@ const MultiInstanceData: FunctionComponent<{
       client,
       groups,
       info: { orgName, label },
+      hasAuth,
     } = resources;
     if (!client) return null;
     if (orgFilter !== "All" && orgFilter !== orgName) return null;
@@ -353,6 +386,7 @@ const MultiInstanceData: FunctionComponent<{
         label={label}
         includeInstance={definitions.length > 1}
         refresh={refresh}
+        hasAuth={hasAuth}
       />
     ));
   });

--- a/src/ts/jwtUtils.test.ts
+++ b/src/ts/jwtUtils.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "@jest/globals";
+import { getOrgIdFromJWT } from "./jwtUtils";
+import type { OAuthResult, OAuthAccess, OAuthIdentity } from "./types";
+
+describe("getOrgIdFromJWT", () => {
+  const mockIdentity: OAuthIdentity = {
+    iss: "https://example.com",
+    sid: "session-id",
+    name: "Test User",
+    sub: "user-123",
+    updated_at: "2024-01-01T00:00:00Z",
+    picture: "https://example.com/picture.jpg",
+  };
+
+  const mockAuthentication = {
+    headers: { Authorization: "Bearer test-token" },
+  };
+
+  const mockLogout = async () => "logged-out";
+
+  test("extracts org ID from valid JWT", () => {
+    const mockAccess: OAuthAccess = {
+      exp: Date.now() + 3600000,
+      "https://snowplowanalytics.com/roles": {
+        user: {
+          id: "user-123",
+          name: "Test User",
+          organization: {
+            id: "org-456",
+            name: "Test Org",
+          },
+        },
+        groups: [],
+      },
+    };
+
+    const login: OAuthResult = {
+      identity: mockIdentity,
+      access: mockAccess,
+      authentication: mockAuthentication,
+      logout: mockLogout,
+    };
+
+    expect(getOrgIdFromJWT(login)).toBe("org-456");
+  });
+
+  test("returns undefined for undefined login", () => {
+    expect(getOrgIdFromJWT(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined when access token is missing", () => {
+    const login = {
+      identity: mockIdentity,
+      access: undefined as any,
+      authentication: mockAuthentication,
+      logout: mockLogout,
+    };
+
+    expect(getOrgIdFromJWT(login)).toBeUndefined();
+  });
+
+  test("returns undefined when roles are missing", () => {
+    const mockAccess = {
+      exp: Date.now() + 3600000,
+    } as OAuthAccess;
+
+    const login: OAuthResult = {
+      identity: mockIdentity,
+      access: mockAccess,
+      authentication: mockAuthentication,
+      logout: mockLogout,
+    };
+
+    expect(getOrgIdFromJWT(login)).toBeUndefined();
+  });
+
+  test("returns undefined when organization is missing", () => {
+    const mockAccess: OAuthAccess = {
+      exp: Date.now() + 3600000,
+      "https://snowplowanalytics.com/roles": {
+        user: {
+          id: "user-123",
+          name: "Test User",
+          organization: undefined as any,
+        },
+        groups: [],
+      },
+    };
+
+    const login: OAuthResult = {
+      identity: mockIdentity,
+      access: mockAccess,
+      authentication: mockAuthentication,
+      logout: mockLogout,
+    };
+
+    expect(getOrgIdFromJWT(login)).toBeUndefined();
+  });
+
+  test("returns undefined when organization ID is missing", () => {
+    const mockAccess: OAuthAccess = {
+      exp: Date.now() + 3600000,
+      "https://snowplowanalytics.com/roles": {
+        user: {
+          id: "user-123",
+          name: "Test User",
+          organization: {
+            id: undefined as any,
+            name: "Test Org",
+          },
+        },
+        groups: [],
+      },
+    };
+
+    const login: OAuthResult = {
+      identity: mockIdentity,
+      access: mockAccess,
+      authentication: mockAuthentication,
+      logout: mockLogout,
+    };
+
+    expect(getOrgIdFromJWT(login)).toBeUndefined();
+  });
+});

--- a/src/ts/jwtUtils.ts
+++ b/src/ts/jwtUtils.ts
@@ -1,0 +1,8 @@
+import type { OAuthResult } from "./types";
+
+export function getOrgIdFromJWT(
+  login: OAuthResult | undefined,
+): string | undefined {
+  return login?.access?.["https://snowplowanalytics.com/roles"]?.user
+    ?.organization?.id;
+}

--- a/src/ts/useSignals.ts
+++ b/src/ts/useSignals.ts
@@ -21,6 +21,7 @@ import {
   type InterventionDefinition,
   type InterventionInstance,
 } from "../components/Signals/SignalsClient";
+import { getOrgIdFromJWT } from "./jwtUtils";
 
 export const useSignals = (
   login: OAuthResult | undefined,
@@ -34,6 +35,7 @@ export const useSignals = (
         keys: AttributeKey[];
         groups: AttributeGroup[];
         interventions: InterventionDefinition[];
+        hasAuth: boolean;
       }
     | undefined
   )[],
@@ -61,6 +63,7 @@ export const useSignals = (
           keys: AttributeKey[];
           groups: AttributeGroup[];
           interventions: InterventionDefinition[];
+          hasAuth: boolean;
         }
       | undefined
     )[]
@@ -277,13 +280,23 @@ export const useSignals = (
     setSignalsDefs([]);
     for (const [i, { client, info }] of apiClients.entries()) {
       const opts = client._getFetchOptions({ method: "GET" });
+      let hasAuth = false;
+
       if (client.sandboxToken) {
         Object.assign(opts.headers, {
           Authorization: `Bearer ${client.sandboxToken}`,
         });
+        hasAuth = true;
       } else {
         // TODO: can we force the creds to update if apiKey is defined?
         Object.assign(opts.headers, login?.authentication.headers);
+
+        const hasApiKey = !!client.apiKey;
+
+        const jwtOrgId = getOrgIdFromJWT(login);
+        const hasJWTForOrg = !!jwtOrgId && jwtOrgId === info.orgId;
+
+        hasAuth = hasApiKey || hasJWTForOrg;
       }
       Promise.all([
         client
@@ -329,6 +342,7 @@ export const useSignals = (
             keys,
             groups,
             interventions,
+            hasAuth,
           };
           return updated;
         });


### PR DESCRIPTION
This PR prevents API calls to `get-online-attributes`, which would fail, by checking for credentials before fetching attribute values. This is done by either checking that the client has an API key for the org, or a JWT with the org ID.

When credentials are missing, it shows the auth prompt instead of making requests for attribute values. Once a key is added via the inspector options, attribute values will begin to be fetched.

