### PR TITLE
Omit credentials in fetch

### DIFF
--- a/src/components/Signals/SignalsClient.test.ts
+++ b/src/components/Signals/SignalsClient.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, jest, test, beforeEach } from "@jest/globals";
+import { SignalsClient } from "./SignalsClient";
+import { version } from "../../../package.json";
+
+jest.mock("@snowplow/signals-core", () => ({
+  SignalsCore: class {
+    constructor() {}
+  },
+}));
+
+global.fetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+describe("SignalsClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("sets X-Signals-Sdk-Name header with version", async () => {
+    const client = new SignalsClient({
+      baseUrl: "https://example.com",
+      apiKey: "test-key",
+      apiKeyId: "test-key-id",
+      organizationId: "test-org",
+    });
+
+    (global.fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as Response);
+
+    await client.fetch("https://example.com/test", {
+      method: "GET",
+      headers: {},
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/test",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-Signals-Sdk-Name": `snowplow-inspector ${version}`,
+        }),
+      }),
+    );
+  });
+});

--- a/src/components/Signals/SignalsClient.ts
+++ b/src/components/Signals/SignalsClient.ts
@@ -32,7 +32,10 @@ export class SignalsClient extends SignalsCore {
     url: string,
     options: SignalsFetchOptions,
   ): Promise<SignalsFetchResponse> {
-    return fetch(url, options);
+    return fetch(url, {
+      ...options,
+      ...{ credentials: "omit" },
+    });
   }
 }
 

--- a/src/components/Signals/SignalsClient.ts
+++ b/src/components/Signals/SignalsClient.ts
@@ -6,6 +6,7 @@ import {
   type SignalsFetchResponse,
 } from "@snowplow/signals-core";
 import type { OAuthResult } from "../../ts/types";
+import { version } from "../../../package.json";
 
 //@ts-ignore: intentional override of private field
 export class SignalsClient extends SignalsCore {
@@ -32,6 +33,7 @@ export class SignalsClient extends SignalsCore {
     url: string,
     options: SignalsFetchOptions,
   ): Promise<SignalsFetchResponse> {
+    options.headers["X-Signals-Sdk-Name"] = `snowplow-inspector ${version}`;
     return fetch(url, {
       ...options,
       ...{ credentials: "omit" },


### PR DESCRIPTION
This removes cookies from the request, which was causing a "Request headers too large" error response from the go server when fetching attribute values on sites with a large amount of cookies.

This should not remove the "Authorization" header set in the signals-core library for the request. Although the docs mention the "omit" option removing the Authorization header (https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials), this should only be for one set by the HTTP authentication flow (https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Authentication), not by us in the client.